### PR TITLE
🎨 Palette: Support 'q' to quit in main menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - CLI Input Handling and URL Validation
 **Learning:** Failing to strip whitespace from user inputs or validate empty inputs leads to confusing errors later. Overly strict URL validation (like only checking for `/videos/`) can cause false positives for valid Facebook URLs (like `/watch` or `/reel/`).
 **Action:** Always strip CLI inputs, handle empty states gracefully with clear error messages, and ensure validation logic accurately reflects all valid input formats.
+
+## 2026-05-16 - Add string-based quit commands in numeric menus
+**Learning:** Users often instinctively type 'q' or 'quit' to exit CLI applications, even when presented with a numeric menu. Failing on these inputs feels hostile.
+**Action:** Always support common string-based exit commands (like 'q', 'quit', 'exit') alongside numeric exit options in CLI menus.

--- a/fb_tools.py
+++ b/fb_tools.py
@@ -275,14 +275,16 @@ def display_menu():
     
     while True:
         try:
-            choice = input(f"\n{Fore.LIGHTCYAN_EX}Enter your choice (1-4): {Fore.RESET}").strip()
+            choice = input(f"\n{Fore.LIGHTCYAN_EX}Enter your choice (1-4) or 'q' to quit: {Fore.RESET}").strip()
+            if choice.lower() in ['q', 'quit', 'exit']:
+                return 4
             choice = int(choice)
             if 1 <= choice <= 4:
                 return choice
             else:
                 print(f"{Fore.LIGHTRED_EX}Invalid choice. Please enter a number between 1 and 4.")
         except ValueError:
-            print(f"{Fore.LIGHTRED_EX}Invalid input. Please enter a number.")
+            print(f"{Fore.LIGHTRED_EX}Invalid input. Please enter a number or 'q' to quit.")
 
 def main():
     """Main function to run the Facebook Tools Suite."""


### PR DESCRIPTION
💡 What: Allowed the main menu to accept 'q', 'quit', or 'exit' as valid commands to cleanly close the application.
🎯 Why: Users often reflexively type "q" to exit CLI applications. Throwing an error when they do so in a numeric menu is frustrating.
♿ Accessibility: Reduces friction in navigating and exiting the CLI, making the tool more forgiving.

---
*PR created automatically by Jules for task [14523199911786427264](https://jules.google.com/task/14523199911786427264) started by @shiliaiwei*