### PR TITLE
🎨 Palette: UX Improvement - Allow natural exit commands in main menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - CLI Input Handling and URL Validation
 **Learning:** Failing to strip whitespace from user inputs or validate empty inputs leads to confusing errors later. Overly strict URL validation (like only checking for `/videos/`) can cause false positives for valid Facebook URLs (like `/watch` or `/reel/`).
 **Action:** Always strip CLI inputs, handle empty states gracefully with clear error messages, and ensure validation logic accurately reflects all valid input formats.
+
+## 2026-05-13 - CLI Natural Exit Behavior
+**Learning:** Users often instinctively type 'q', 'quit', or 'exit' when presented with a command line prompt, rather than searching the menu for the designated exit number. Returning a vague "Invalid input" loop when a user simply wants to quit creates an extremely frustrating UX.
+**Action:** Always gracefully handle standard exit conventions like 'q', 'quit', or 'exit' in CLI loops, regardless of what the main prompt emphasizes. Ensure error messages suggest these common exit paths explicitly.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+__pycache__/
+*.pyc

--- a/fb_tools.py
+++ b/fb_tools.py
@@ -275,14 +275,19 @@ def display_menu():
     
     while True:
         try:
-            choice = input(f"\n{Fore.LIGHTCYAN_EX}Enter your choice (1-4): {Fore.RESET}").strip()
+            choice = input(f"\n{Fore.LIGHTCYAN_EX}Enter your choice (1-4, or 'q' to quit): {Fore.RESET}").strip()
+
+            # Handle standard exit commands
+            if choice.lower() in ['q', 'quit', 'exit']:
+                return 4
+
             choice = int(choice)
             if 1 <= choice <= 4:
                 return choice
             else:
                 print(f"{Fore.LIGHTRED_EX}Invalid choice. Please enter a number between 1 and 4.")
         except ValueError:
-            print(f"{Fore.LIGHTRED_EX}Invalid input. Please enter a number.")
+            print(f"{Fore.LIGHTRED_EX}Invalid input. Please enter a number between 1 and 4, or 'q' to quit.")
 
 def main():
     """Main function to run the Facebook Tools Suite."""


### PR DESCRIPTION
💡 What: Added the ability for users to exit the CLI tool by typing `'q'`, `'quit'`, or `'exit'` instead of having to explicitly type the number `4`. Also updated the prompt and error messaging to clarify this option.
🎯 Why: CLI users typically expect natural, standard commands like 'q' to quit applications. Failing to support this and instead returning an unhelpful "Invalid input" error creates a frustrating loop that degrades the user experience.
📸 Before/After: N/A (CLI change)
♿ Accessibility: Reduces cognitive load and frustration for users who are accustomed to standard terminal commands.

---
*PR created automatically by Jules for task [11506616482179311165](https://jules.google.com/task/11506616482179311165) started by @shiliaiwei*