### PR TITLE
🎨 Palette: Add clear screen for cleaner CLI menu navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-05-19 - Graceful Exit on Empty Inputs
 **Learning:** CLI tools that throw hostile red error messages (e.g., "Error: No URL provided.") when a user submits an empty input can make users feel penalized for simply changing their mind or wanting to back out of a menu option.
 **Action:** Treat empty inputs in sub-menus as a deliberate "Cancel/Back" action. Provide a friendly yellow message (e.g., "Operation cancelled. Returning to main menu.") and explicitly hint this in the prompt (e.g., "or press Enter to cancel").
+
+## 2026-05-19 - Reducing cognitive load with CLI screen clears
+**Learning:** Endless scrolling in CLI menus quickly leads to a cluttered terminal, making it difficult for users to track where they are or focus on the current task.
+**Action:** Implement screen clearing (e.g., `os.system('cls' if os.name == 'nt' else 'clear')`) between distinct task states and when looping back to the main menu to maintain a clean, focused workspace and reduce cognitive load.

--- a/fb_tools.py
+++ b/fb_tools.py
@@ -12,6 +12,10 @@ import shutil
 # Initialize Colorama
 init(autoreset=True)
 
+def clear_screen():
+    """Clear the terminal screen."""
+    os.system('cls' if os.name == 'nt' else 'clear')
+
 def print_colored_logo():
     """Generate and display the EIRSVi logo with color effects."""
     # Generate ASCII art for the logo "EIRSVi"
@@ -289,7 +293,8 @@ def display_menu():
 
 def main():
     """Main function to run the Facebook Tools Suite."""
-    # Display welcome message
+    # Clear screen initially and display welcome message
+    clear_screen()
     print_welcome()
     
     while True:
@@ -312,6 +317,10 @@ def main():
         if continue_choice.lower() == 'q':
             print(f"\n{Fore.LIGHTGREEN_EX}Thank you for using Facebook Tools Suite! Goodbye!")
             break
+
+        # Clear screen and re-display welcome message for the next iteration
+        clear_screen()
+        print_welcome()
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
💡 What: Implemented a cross-platform clear screen function that triggers before re-displaying the main menu in `fb_tools.py`.
🎯 Why: Without clearing the screen, continuous usage of the CLI app creates endless terminal scroll clutter, overwhelming the user and causing cognitive load. Clearing the screen between tasks keeps the UI focused and clean.
♿ Accessibility: Reduces visual clutter and helps users easily locate the current options without having to scroll back.

---
*PR created automatically by Jules for task [12215083688022711982](https://jules.google.com/task/12215083688022711982) started by @shiliaiwei*